### PR TITLE
Fix missing media links in detail view

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,11 +74,14 @@
    const pageData=state.filtered.slice(start,start+PAGE_SIZE);
    if(!pageData.length){main.innerHTML='<p class="py-10 text-center">Nessun sermone trovato.</p>'; return;}
    const cards=pageData.map(r=>{
-     const tags=[];
-     if(r['URL video']) tags.push('<span class="text-xs bg-red-100 text-red-700 px-2 py-1 rounded">Video</span>');
-     if(r['URL audio']) tags.push('<span class="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">Audio</span>');
-     if(r['URL testo']) tags.push('<span class="text-xs bg-green-100 text-green-700 px-2 py-1 rounded">Testo</span>');
-     const img=r['URL immagine']||`https://picsum.photos/seed/${r.id}/400/225`;
+    const videoUrl=r['Link video']||r['URL video'];
+    const audioUrl=r['Link audio']||r['URL audio'];
+    const textUrl=r['Link testo']||r['URL testo'];
+    const tags=[];
+    if(videoUrl) tags.push('<span class="text-xs bg-red-100 text-red-700 px-2 py-1 rounded">Video</span>');
+    if(audioUrl) tags.push('<span class="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">Audio</span>');
+    if(textUrl) tags.push('<span class="text-xs bg-green-100 text-green-700 px-2 py-1 rounded">Testo</span>');
+    const img=r['Link immagine']||r['URL immagine']||`https://picsum.photos/seed/${r.id}/400/225`;
      return `<a href="#/sermon/${r.id}" class="bg-white rounded shadow overflow-hidden flex flex-col">
        <img src="${img}" alt="${r['Titolo predicazione']}" class="w-full h-48 object-cover">
        <div class="p-4 flex-1 flex flex-col">
@@ -102,11 +105,14 @@
  function renderDetail(id){
    const r=state.data.find(x=>x.id==id);
    if(!r){main.innerHTML='<p class="py-10 text-center">Sermone non trovato.</p>'; return;}
-   const img=r['URL immagine']||`https://picsum.photos/seed/${r.id}/800/450`;
-   let media='';
-   if(r['URL video']) media+=`<div class="mb-4 aspect-video"><iframe class="w-full h-full" src="${r['URL video'].replace('watch?v=','embed/')}" allowfullscreen></iframe></div>`;
-   if(r['URL audio']) media+=`<audio controls src="${r['URL audio']}" class="w-full mb-4"></audio>`;
-   const textLink=r['URL testo']?`<a href="${r['URL testo']}" target="_blank" class="inline-block bg-green-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-file-lines mr-2"></i>Leggi il testo</a>`:'';
+  const img=r['Link immagine']||r['URL immagine']||`https://picsum.photos/seed/${r.id}/800/450`;
+  const videoUrl=r['Link video']||r['URL video'];
+  const audioUrl=r['Link audio']||r['URL audio'];
+  const textUrl=r['Link testo']||r['URL testo'];
+  let media='';
+  if(videoUrl) media+=`<div class="mb-4 aspect-video"><iframe class="w-full h-full" src="${videoUrl.replace('watch?v=','embed/')}" allowfullscreen></iframe></div>`;
+  if(audioUrl) media+=`<audio controls src="${audioUrl}" class="w-full mb-4"></audio>`;
+  const textLink=textUrl?`<a href="${textUrl}" target="_blank" class="inline-block bg-green-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-file-lines mr-2"></i>Leggi il testo</a>`:'';
    main.innerHTML=`<div class="bg-white shadow rounded overflow-hidden">
      <img src="${img}" alt="${r['Titolo predicazione']}" class="w-full object-cover max-h-[450px]">
      <div class="p-4">


### PR DESCRIPTION
## Summary
- Support `Link` column names for video, audio, text, and image
- Display media links correctly in sermon detail and list views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974a3d2cdc8321ab1794ee269d4e5b