### PR TITLE
Fix sermon card info and resource loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,11 @@
  const searchInput=document.getElementById('search');
  const yearSelect=document.getElementById('filter-year');
  const verseSelect=document.getElementById('filter-verse');
- function fetchCSV(){return fetch('data/sermoni.csv').then(r=>r.text());}
+ function fetchCSV(){
+   return fetch('data/sermoni.csv')
+     .then(r=>r.arrayBuffer())
+     .then(b=>new TextDecoder('windows-1252').decode(b));
+ }
  function parseCSV(text){
    const rows=[]; let field='',row=[],inQuotes=false; let i=0;
    while(i<text.length){const c=text[i];
@@ -94,7 +98,7 @@ function applyFilters(){
   renderList();
   updateHash();
  }
- function renderList(){
+function renderList(){
    const start=(state.page-1)*PAGE_SIZE;
    const pageData=state.filtered.slice(start,start+PAGE_SIZE);
    if(!pageData.length){main.innerHTML='<p class="py-10 text-center">Nessun sermone trovato.</p>'; return;}
@@ -111,11 +115,12 @@ function applyFilters(){
        <img src="${img}" alt="${r['Titolo predicazione']}" class="w-full h-48 object-cover">
        <div class="p-4 flex-1 flex flex-col">
          <h3 class="font-semibold mb-2">${r['Titolo predicazione']}</h3>
-         <p class="text-sm text-gray-500 mb-2">${r['Data']} · ${r['Predicatore']}</p>
+         <p class="text-sm text-gray-500">${r['Data']} · ${r['Predicatore']}</p>
+         <p class="text-sm text-gray-700 mb-2">${r['Testo biblico']}</p>
          <div class="mt-auto space-x-1">${tags.join(' ')}</div>
        </div>
      </a>`;
-   }).join('');
+  }).join('');
    const totalPages=Math.ceil(state.filtered.length/PAGE_SIZE)||1;
    const pagButtons=[];
    if(state.page>1) pagButtons.push(`<button data-page="${state.page-1}" aria-label="Pagina precedente" class="px-3 py-1 border rounded">«</button>`);
@@ -125,16 +130,37 @@ function applyFilters(){
    if(state.page<totalPages) pagButtons.push(`<button data-page="${state.page+1}" aria-label="Pagina successiva" class="px-3 py-1 border rounded">»</button>`);
    main.innerHTML=`<div class="grid gap-4 sm:grid-cols-2">${cards}</div>
    <div class="flex justify-center mt-4 space-x-2">${pagButtons.join('')}</div>`;
-   main.querySelectorAll('button[data-page]').forEach(btn=>btn.addEventListener('click',e=>{state.page=+e.target.getAttribute('data-page'); renderList(); updateHash();}));
- }
-  function renderDetail(id){
+  main.querySelectorAll('button[data-page]').forEach(btn=>btn.addEventListener('click',e=>{state.page=+e.target.getAttribute('data-page'); renderList(); updateHash();}));
+}
+async function checkResource(url){
+  if(!url) return '';
+  try{
+    const res=await fetch(url,{method:'HEAD'});
+    return res.ok?url:'';
+  }catch(e){
+    return '';
+  }
+}
+
+async function renderDetail(id){
     const r=state.data.find(x=>x.id==id);
     if(!r){main.innerHTML='<p class="py-10 text-center">Sermone non trovato.</p>'; return;}
+    main.innerHTML='<p class="py-10 text-center">Caricamento...</p>';
     const img=r['Link immagine']||r['URL immagine']||`https://picsum.photos/seed/${r.id}/800/450`;
-    const videoUrl=r['Link video']||r['URL video'];
-    const audioUrl=r['Link audio']||r['URL audio'];
-    const textUrl=r['Link testo']||r['URL testo'];
-    const videoSection=`<details ${videoUrl?'open':''} class="mb-4 border rounded"><summary class="cursor-pointer p-2 font-semibold">Video</summary>${videoUrl?`<div class=\\"mt-2 aspect-video\\"><iframe class=\\"w-full h-full\\" src=\\"${videoUrl.replace('watch?v=','embed/')}\\" allowfullscreen></iframe></div>`:`<p class=\\"p-2 text-gray-500\\">Video non disponibile.</p>`}</details>`;
+    const videoUrl=await checkResource(r['Link video']||r['URL video']);
+    const audioUrl=await checkResource(r['Link audio']||r['URL audio']);
+    const textUrl=await checkResource(r['Link testo']||r['URL testo']);
+    let videoContent;
+    if(videoUrl){
+      if(/youtube\.com|youtu\.be/.test(videoUrl)){
+        videoContent=`<div class=\\"mt-2 aspect-video\\"><iframe class=\\"w-full h-full\\" src=\\"${videoUrl.replace('watch?v=','embed/')}\\" allowfullscreen></iframe></div>`;
+      }else{
+        videoContent=`<div class=\\"mt-2\\"><video controls src=\\"${videoUrl}\\" class=\\"w-full\\"></video></div>`;
+      }
+    }else{
+      videoContent=`<p class=\\"p-2 text-gray-500\\">Video non disponibile.</p>`;
+    }
+    const videoSection=`<details ${videoUrl?'open':''} class="mb-4 border rounded"><summary class="cursor-pointer p-2 font-semibold">Video</summary>${videoContent}</details>`;
     const audioSection=`<details class="mb-4 border rounded"><summary class="cursor-pointer p-2 font-semibold">Audio</summary>${audioUrl?`<div class=\\"p-2\\"><audio controls src=\\"${audioUrl}\\" class=\\"w-full\\"></audio></div>`:`<p class=\\"p-2 text-gray-500\\">Audio non disponibile.</p>`}</details>`;
     const textSection=`<details class="mb-4 border rounded"><summary class="cursor-pointer p-2 font-semibold">Testo</summary>${textUrl?`<div class=\\"p-2\\"><a href=\\"${textUrl}\\" target=\\"_blank\\" class=\\"inline-block bg-green-600 text-white px-4 py-2 rounded\\"><i class=\\"fa-solid fa-file-lines mr-2\\"></i>Leggi il testo</a></div>`:`<p class=\\"p-2 text-gray-500\\">Testo non disponibile.</p>`}</details>`;
     main.innerHTML=`<div class="bg-white shadow rounded overflow-hidden">


### PR DESCRIPTION
## Summary
- Add verse reference to sermon list cards
- Decode CSV with Windows-1252 to fix special characters
- Check media resource availability and display fallback when missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689750354d348321b2c30bdc3bab6bf4