### PR TITLE
Fix encoding for sermon titles

### DIFF
--- a/data/sermoni.csv
+++ b/data/sermoni.csv
@@ -13,20 +13,20 @@ Data,Link video,Link audio,Link testo,Link immagine,Titolo predicazione,Testo bi
 2025-03-23,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/23.03.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/23.03.2025audio.m4a,,,False sicurezze VS vera appartenenza,Romani 2:17-29,Fabio,			
 2025-03-30,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/30.03.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/30.03.2025audio.m4a,,,i privilegi umani giudicano la grazia di Dio,Romani 3:1-8,Samuele,			
 2025-04-06,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06-04-25.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06-04-25.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06-04-25+Nessuno...+Neppure+Uno.pdf,,Nessuno... neppure uno,Romani 3:9-20,Fabio,			
-2025-04-13,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.mp4 ,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.txt,,Chiesa e SocietÃ ,Matteo 10:16,Francesco Abortivi,			
+2025-04-13,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.mp4 ,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130425.txt,,Chiesa e Società,Matteo 10:16,Francesco Abortivi,			
 2025-04-20,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/20.04.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/20.04.2025audio.m4a,,,"La Pasqua oggi, tra passato, presente e futuro",Esodo 12:1-14,Samuele,			
 2025-04-27,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/270425.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/270425.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/270425.txt,,Dio Rivela la sua Giustizia,Romani 3:21-22,Fabio,			
 2025-05-04,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/04.05.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/04.05.2025audio.m4a ,,,La giustizia di Dio,Romani 3:22-24,Samuele,			
 2025-05-11,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/110525.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/110525.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/110525.txt ,,Come Lodare Dio,Salmo 100,Fabio,			
-2025-05-18,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.5.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.5.2025audio.m4a,,,La legge Ã¨ uguale per tutti,Romani 1-2-3,Simone Moretti,			
+2025-05-18,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.5.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.5.2025audio.m4a,,,La legge è uguale per tutti,Romani 1-2-3,Simone Moretti,			
 2025-05-25,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/250525.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/250525.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/250525.txt,,La chiamata della tua vita,Marco 2:13-17,Oscar Bassett,			
 2025-06-01,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/01.06.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/01.06.2025audio.m4a,,,La giustizia di Dio nel sangue di Cristo,Romani 3:25-26,Fabio,			
 2025-06-08,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/080625.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/080625.m4a,,,Discelpoli radicali,Luca 6:20-26,Franco Deriu,			
 2025-06-15,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/15.06.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/15.06.2025audio.m4a,,,Il tuo vanto davanti alla grazia di Dio,Romani 3:27-31,Samuele,			
-2025-06-22,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/22.06.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/22.06.2025audio.m4a,,,"La fede: il canale attraverso cui Dio opera la sua grazia, lâ€™esempio di Abraamo",Romani 4:1-8,Samuele,			
-2025-06-29,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.txt,,"UNA FEDE CHE GIUSTIFICA: la nostra identitÃ  nella grazia, non nelle opere",Romani 4:-9-17,Fabio,			
-2025-07-06,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06.07.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06.07.2025audio.m4a,,,"la nostra identitÃ  nella grazia, non nelle opere",Rom. 4:18-25,Samuele,			
-2025-07-13,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130725.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130725.m4a,,,DOVâ€™Eâ€™ LA TUA FESTA?,Luke 15:11-32,"Alessandro Naldoni			
+2025-06-22,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/22.06.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/22.06.2025audio.m4a,,,"La fede: il canale attraverso cui Dio opera la sua grazia, l'esempio di Abraamo",Romani 4:1-8,Samuele,			
+2025-06-29,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.m4a,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/290625.txt,,"UNA FEDE CHE GIUSTIFICA: la nostra identità nella grazia, non nelle opere",Romani 4:-9-17,Fabio,			
+2025-07-06,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06.07.2025.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/06.07.2025audio.m4a,,,"la nostra identità nella grazia, non nelle opere",Rom. 4:18-25,Samuele,			
+2025-07-13,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130725.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/130725.m4a,,,DOV'È LA TUA FESTA?,Luke 15:11-32,"Alessandro Naldoni			
 Paolo Nagellini			
 Emanuele Berti",			
 2025-07-20,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/200725.mp4,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/200725.m4a,,,la vera fede combatte la paura!,Numeri 13 e 14,Samuele,			
@@ -36,22 +36,22 @@ Emanuele Berti",
 2024-01-21,,,,,Il tumulto di Efeso,Atti 19:23-41,"Alessandro, Andrea, Emanuele",https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/21.01.2024Ale_Em.mp4			
 2024-01-28,,,,,Paolo in Macedonia e in Grecia,Atti 20:1-16,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/28.01.2024.mp4			
 2024-02-11,,,,,Filemone,Filemone,Marco Saillen,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/11.02.2024.mp4			
-2024-02-18,,,,,"Paolo verso Gerusalemme, lâ€™amore dei credenti e il costo del discepolato",Atti 21:1-16,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.02.2024.mp4			
-2024-02-25,,,,,L'umiltÃ  che alimenta l'unitÃ ,Atti 21:17-26,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/25.02.2024.mp4			
-2024-03-03,,,,,Congiura contro Paolo: lâ€™inganno dellâ€™uomo e la provvidenza di Dio,Atti 21:27-40,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/03.03.2024.mp4			
+2024-02-18,,,,,"Paolo verso Gerusalemme, l'amore dei credenti e il costo del discepolato",Atti 21:1-16,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18.02.2024.mp4			
+2024-02-25,,,,,L'umiltà che alimenta l'unità,Atti 21:17-26,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/25.02.2024.mp4			
+2024-03-03,,,,,Congiura contro Paolo: l'inganno dell'uomo e la provvidenza di Dio,Atti 21:27-40,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/03.03.2024.mp4			
 2024-03-10,,,,,"Sovrano sul lavoro, sovrano sul sesso",Genesi 39:1-12,Michel di Felice Antonio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/10+marzo.mp4			
-2024-03-17,,,,,Qual Ã¨ la tua storia?,Atti 22:1-21,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/17.03.2024.mp4			
+2024-03-17,,,,,Qual è la tua storia?,Atti 22:1-21,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/17.03.2024.mp4			
 2024-03-24,,,,,Casa dolce casa,1 Pietro 2:1-5,Stefano Standridge,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/24032024.mp4			
 2024-03-31,,,,,La Pasqua cristiana,Esodo 12:42,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/31.03.2024.mp4			
 2024-04-07,,,,,La provvidenza di Dio,Atti 22:22-23:11,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/07.04.2024.mp4			
 2024-04-14,,,,,Momenti della vita di Pietro che lo hanno formato,Mt 12:22-29	 Lu 22:59-62	 Gv 21:15-19	 At 1:3,Franco Deriu,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/15.04.2024.mp4
-2024-04-21,,,,,Congiura contro Paolo: lâ€™inganno dellâ€™uomo e la fedele provvidenza di Dio,Atti 23:12-35,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/21.04.2024.mp4			
+2024-04-21,,,,,Congiura contro Paolo: l'inganno dell'uomo e la fedele provvidenza di Dio,Atti 23:12-35,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/21.04.2024.mp4			
 2024-04-28,,,,,Paolo si difende davanti al governatore Felice,Atti 24:1-21,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/28.04.2024.mp4			
 2024-05-05,,,,,Non procrastinare ,Atti 24:22-27,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/05.05.2024.mp4			
 2024-05-12,,,,,Paolo davanti a Festo,Atti 25:1-12,"Alessandro, Andrea e Emanuele",https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/12.05.2024BB.mp4			
 2024-05-19,,,,,Viaggio nel peccato.. Immagini della storia dell'uomo,Atti 25:13-27,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/05.19.2024.mp4			
 2024-05-26,,,,,Radicalmente cambiato,Atti 26:1-18,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/26.05.2024.mp4			
-2024-06-02,,,,,tutto secondo i piani di Dio: il prigioniero Paolo sarÃ  giudicato a Roma!,Atti 26:19-32,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/02.06.2024.mp4			
+2024-06-02,,,,,tutto secondo i piani di Dio: il prigioniero Paolo sarà giudicato a Roma!,Atti 26:19-32,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/02.06.2024.mp4			
 2024-06-09,,,,,Atleti di Cristo,Filippesi 3:15-21,Simone Bertolini,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/09.06.2024.mp4			
 2024-06-16,,,,,Il viaggio di un testimone di Cristo. La fede tra prove di provvidenza per essere liberati non dalla prova ma nella prova - parte 1,Atti 27:1-26,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/16.06.2024.mp4			
 2024-06-23,,,,,Il viaggio di un testimone di Cristo. La fede tra prove di provvidenza per essere liberati non dalla prova ma nella prova - parte 2,Atti 27:1-26,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/23.06.2024.mp4			
@@ -70,29 +70,29 @@ Emanuele Berti",
 2024-09-22,,,,,La chiesa che serve,,Franco Deriu - ritiro chiesa,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/Sessione+5.m4a			
 2024-09-29,,,,,Una strana chiamata - parte 1,Esodo 3:1-10,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/29.09.2024.mp4			
 2024-10-13,,,,,,1 Tessalonicesi 5:1-11,Nunzio Sabatasso,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/13.10.2024.mp4			
-2024-10-20,,,,,IdentitÃ  in Cristo,Romani 1:1,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/20.10.2024.mp4			
+2024-10-20,,,,,Identità in Cristo,Romani 1:1,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/20.10.2024.mp4			
 2024-10-27,,,,,Una trana chiamata - parte 2,Esodo 3:1-10,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/27.10.2024.mp4			
 2024-11-03,,,,,il Vangelo di Dio,Romani 1:1-7,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/03.11.2024.mp4			
 2024-11-10,,,,,Una trana chiamata - parte 3,Esodo 3:1-10,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/10.11.2024.mp4			
-2024-11-17,,,,,GesÃ¹ ti cerca,Luca 19:1-10,Luigi Palombo,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/17.11.2024.mp4			
+2024-11-17,,,,,Gesù ti cerca,Luca 19:1-10,Luigi Palombo,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/17.11.2024.mp4			
 2024-11-24,,,,,il vangelo che opera nella vita del credente,Romani 1:8-15,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/24.11.2024.mp4			
 2024-12-01,,,,,,Luca 5:12-16,Francesco Grassi,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/01.12.2024.mp4			
 2024-12-08,,,,,,Isaia 42:1-3,Robby Roberts,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/08.12.2024.mp4			
 2024-12-15,,,,,,Luca 10:25-37,"Predicazione Alejandro, Emanuele e Alessandro",https://drive.google.com/file/d/1-HouHQdKCobgXF8rgdFyfNUi2zAfcyah/view?usp=sharing			
-2024-12-22,,,,,Il dono di Dio per l'umanitÃ ,Luca 2:1-20,Fabio,https://drive.google.com/file/d/1vOw5ND-fdJD3rGieM5G9CcgOX4BEuRSa/view?usp=sharing			
+2024-12-22,,,,,Il dono di Dio per l'umanità,Luca 2:1-20,Fabio,https://drive.google.com/file/d/1vOw5ND-fdJD3rGieM5G9CcgOX4BEuRSa/view?usp=sharing			
 2024-12-29,,,,,,,Samuele,https://drive.google.com/file/d/1wHIvljRosycHFF1PRFNxF5HtKx9XI_6y			
 2023-03-12,,,,,Missione im-possible,Atti 1:1-11,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/120323.mp4			
-2023-03-19,,,,,Lâ€™attesa dello Spirito Santo,Atti 1:12-26,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/IMG_8310.mp4			
+2023-03-19,,,,,L'attesa dello Spirito Santo,Atti 1:12-26,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/IMG_8310.mp4			
 2023-03-26,,,,,Promessa Mantenuta,Atti 2:1-21,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/IMG_1022.MOV			
-2023-04-02,,,,,GesÃ¹ Ã¨ il Messia,Atti 2:21-36,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/020423.mp4			
+2023-04-02,,,,,Gesù è il Messia,Atti 2:21-36,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/020423.mp4			
 2023-04-09,,,,,"Pasqua: ""il Dio risorto, davanti alla sua tomba vuota, chiede anche a noi chi stiamo cercando!""",Gv. 20:15	Â Gv.Â 6,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/090423.mp4		
 2023-04-16,,,,,Le prime conversioni,Atti 2:37-47,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/160423.mp4			
 2023-04-30,,,,,L'inizio della persecuzione della chiesa,Atti 4:1-22,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/300323.mp4			
-2023-05-07,,,,,La risposta della chiesa: la sua unitÃ  nello Spirito,Atti 4:23-37,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/070523.mp4			
+2023-05-07,,,,,La risposta della chiesa: la sua unità nello Spirito,Atti 4:23-37,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/070523.mp4			
 2023-05-14,,,,,Anania e Saffira,Atti 5:1-11,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/140523.mp4			
 2023-05-21,,,,,La potenza dello Spirito Santo ,Atti 5:12-32,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/210523.mp4			
 2023-05-28,,,,,Guidati dal timore di Dio,Atti 5:33-41,Daniele Pasquale,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/280523.mp4			
-2023-06-04,,,,,Conflitti e fedeltÃ ,Atti 6,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/04_06_2023.mp4			
+2023-06-04,,,,,Conflitti e fedeltà,Atti 6,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/04_06_2023.mp4			
 2023-06-11,,,,,Il discorso di Stefano diacono e apologeta,Atti 7,Samuele,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/11_06_2023.mp4			
 2023-06-18,,,,,Filippo.. Ubbidienza oltre le discriminazioni,Atti 8,Fabio,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/18_06_23.mp4			
 2023-06-25,,,,,Conversione di Saulo,Atti 9:1-31,Cristiano De Chirico,https://chiesa-logos.s3.eu-west-1.amazonaws.com/Sermoni/25.06.2023.mp4			


### PR DESCRIPTION
## Summary
- Clean up Italian sermon titles by removing encoding artifacts (apostrophes and accented characters)

## Testing
- `python - <<'PY'
import csv
with open('data/sermoni.csv', newline='') as f:
    rows=list(csv.reader(f))
print('rows', len(rows))
print(rows[25][5])
print(rows[26][5])
print(rows[27][5])
print(rows[28][5])
print(rows[29][5])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68975929d8748321a8ea5e7b220bd993